### PR TITLE
Update Ubuntu runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
@@ -20,6 +20,7 @@ RUN apt-get update && \
 		flex \
 		git \
 		git-core \
+		gitlint \
 		libasound2-dev \
 		libdbus-1-dev \
 		libdw-dev \
@@ -39,16 +40,20 @@ RUN apt-get update && \
 		libtool \
 		libudev-dev \
 		libxml2-dev \
-		locales \
 		openssl \
 		patch \
 		pkg-config \
-		python-docutils \
-		python-pygments \
+		python3-docutils \
+		python3-pygments \
 		python3 \
 		python3-pip \
 		python3-docutils \
 		python3-pygments \
+		python3-git \
+		python3-junitparser \
+		python3-github \
+		python3-requests \
+		python3-ply \
 		qemu-system-x86 \
 		systemd \
 		udev \
@@ -57,12 +62,10 @@ RUN apt-get update && \
 		xxd && \
 	rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && apt-get install -y locales
+
 RUN locale-gen en_US.UTF-8
 ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
-
-# Install Python3 Library
-RUN pip3 install --no-cache-dir setuptools && \
-	pip3 install --no-cache-dir gitlint gitpython junitparser pygithub requests ply
 
 RUN wget --no-verbose --no-check-certificate \
 	https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl -P /usr/bin/ && \


### PR DESCRIPTION
20.04 is unsupported since the end of May 2025.

26.04 is the latest LTS version.

Update the name of a few Python packages, and install the Python modules we used to install manually through packages too, as the Python installation doesn't like installing modules system-wide, for fear of breaking things:
```
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
[...]
note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages. hint: See PEP 668 for the detailed specification.
```

Tested on Fedora 44 using podman.